### PR TITLE
Fix many-to-many by finding related model from descriptor

### DIFF
--- a/admin_auto_filters/filters.py
+++ b/admin_auto_filters/filters.py
@@ -48,9 +48,18 @@ class AutocompleteFilter(admin.SimpleListFilter):
         remote_field = model._meta.get_field(self.field_name).remote_field
 
         attrs = self.widget_attrs.copy()
-       
+
+        field_desc = getattr(model, self.field_name)
+        try:
+            # First try to get the related using logic from ManyToManyDescriptor; any of these accesses might fail
+            related_model = field_desc.rel.related_model if field_desc.reverse else field_desc.rel.model
+            queryset = related_model.objects.get_queryset()
+        except:
+            # Fall back to behavior that should work with ReverseManyToOneDescriptor created by ForeignKey
+            queryset = field_desc.get_queryset()
+
         field = forms.ModelChoiceField(
-            queryset=getattr(model, self.field_name).get_queryset(),
+            queryset=queryset,
             widget=AutocompleteSelect(remote_field, model_admin.admin_site),
             required=False
         )


### PR DESCRIPTION
In https://github.com/farhan0581/django-admin-autocomplete-filter/blob/master/admin_auto_filters/filters.py#L53 we attempt to call `.get_queryset()` on the descriptor of the field. For foreign keys this works fine, but for ManyToManyDescriptor (which is present if you're referencing a ManyToManyField), Django never defines `get_queryset` on the class or its superclass: https://github.com/django/django/blob/master/django/db/models/fields/related_descriptors.py#L748

This is kind of an oversight and broken-duck-typing on the Django team's part, and it's trivially and harmlessly monkey-patched by doing the following somewhere, which causes the filter to work as intended.

```python
ManyToManyDescriptor.get_queryset = lambda self: self.rel.model.objects.get_queryset()
```

But the correct fix would be to fall back to a call like this in the filter code itself - this PR does exactly that!